### PR TITLE
Fix Classic Dev Mode selection on launcher config  for GWT >= 2.7

### DIFF
--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/processors/SuperDevModeArgumentProcessor.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/processors/SuperDevModeArgumentProcessor.java
@@ -183,12 +183,6 @@ public class SuperDevModeArgumentProcessor implements ILaunchConfigurationProces
       programArgs.remove(indexDisabled);
     }
 
-    // Verify its a GWT > 2.7, just in case another version snuck in.
-    if (!GwtVersionUtil.isGwtVersionGreaterOrEqualTo27(javaProject)) {
-      // Previously created in GWT 2.7, but switched to GWT 2.4 will do this
-      return;
-    }
-
     // Super dev mode is on by default, on: nothing off: -nosuperDevMode
     if (!superDevModeEnabled) {
       programArgs.add(0, SUPERDEVMODE_DISABLED_ARG);


### PR DESCRIPTION
I think this PR should fix issue mentioned in https://github.com/gwt-plugins/gwt-eclipse-plugin/issues/61#issuecomment-128171265.