### PR TITLE
Fixing using GWT 2.4.0 or older sdk.

### DIFF
--- a/plugins/com.google.gdt.eclipse.core/src/com/google/gdt/eclipse/core/console/MessageConsoleUtilities.java
+++ b/plugins/com.google.gdt.eclipse.core/src/com/google/gdt/eclipse/core/console/MessageConsoleUtilities.java
@@ -29,7 +29,7 @@ public class MessageConsoleUtilities {
    * <code>consoleName</code>. If no console by that name exists then one is
    * created. The returned console is cleared; callers of this method can decide
    * when to activate it.
-   * 
+   *
    * @param consoleName name of the console
    * @param imageDescriptor image descriptor to use
    * @return {@link CustomMessageConsole} with the given
@@ -52,6 +52,28 @@ public class MessageConsoleUtilities {
       consoleManager.addConsoles(new IConsole[] {messageConsole});
     } else {
       messageConsole.clearConsole();
+    }
+
+    return messageConsole;
+  }
+
+  public static CustomMessageConsole getMessageConsoleKeepLog(String consoleName,
+      ImageDescriptor imageDescriptor) {
+    CustomMessageConsole messageConsole = null;
+    IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+    for (IConsole console : consoleManager.getConsoles()) {
+      if (console.getName().equals(consoleName)
+          && console instanceof CustomMessageConsole) {
+        messageConsole = (CustomMessageConsole) console;
+        break;
+      }
+    }
+
+    if (messageConsole == null) {
+      messageConsole = new CustomMessageConsole(consoleName, imageDescriptor);
+      consoleManager.addConsoles(new IConsole[] {messageConsole});
+    } else {
+      //messageConsole.clearConsole();
     }
 
     return messageConsole;

--- a/plugins/com.google.gdt.eclipse.maven/src/com/google/gdt/eclipse/maven/launch/MavenClasspathProvider.java
+++ b/plugins/com.google.gdt.eclipse.maven/src/com/google/gdt/eclipse/maven/launch/MavenClasspathProvider.java
@@ -102,13 +102,13 @@ public class MavenClasspathProvider extends ModuleClasspathProvider {
      * Figure out if we are supposed to be relying on the default classpath or not. The default
      * classpath is the one that is generated for a launch configuration based on the launch
      * configuration's project's build classpath.
-     * 
+     *
      * To determine whether or not to rely on the default classpath, we look at the
      * ATTR_DEFAULT_CLASSPATH attribute of the launch configuration. This attribute is set whenever
      * the user makes a change to the launch configuration classpath using the add/remove buttons.
      * From this point on, Eclipse will respect the user's changes and will not replace their
      * entries with the classpath that it computes.
-     * 
+     *
      * However, users can specify that they want to restore the behavior of having Eclipse compute
      * the classpath by clicking on the "Restore Default Entries" button. This causes the
      * ATTR_DEFAULT_ATTRIBUTE to be unset for a launch configuration.
@@ -162,4 +162,5 @@ public class MavenClasspathProvider extends ModuleClasspathProvider {
 
     return resolvedEntriesList.toArray(new IRuntimeClasspathEntry[resolvedEntriesList.size()]);
   }
+
 }

--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/GWTLaunchConfiguration.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/GWTLaunchConfiguration.java
@@ -44,8 +44,8 @@ public class GWTLaunchConfiguration {
   public static List<String> computeJunitDynamicVMArgsAsList(IJavaProject javaProject) {
     List<String> out = computeDynamicVMArgs(javaProject);
 
-    // Default the maximum heap size to 512 MB
-    out.add("-Xmx512m");
+    // Default the maximum heap size to 1g
+    out.add("-Xmx1g");
 
     return out;
   }

--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ModuleClasspathProvider.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ModuleClasspathProvider.java
@@ -248,7 +248,6 @@ public class ModuleClasspathProvider extends StandardClasspathProvider {
     String message = "~~~~~> There is more than one jar on the classpath? Recommended removing one: ";
 
     int countDupsGwtUser = 0;
-    int countDupsGwtDev = 0;
     int countDupsCodeServer = 0;
 
     for (int i = 0; i < resolvedEntries.length; i++) {
@@ -259,17 +258,13 @@ public class ModuleClasspathProvider extends StandardClasspathProvider {
           countDupsGwtUser++;
         }
 
-        if (entry.getPath().toString().toLowerCase().contains("gwt-dev")) {
-          countDupsGwtDev++;
-        }
-
         if (entry.getPath().toString().toLowerCase().contains("gwt-codeserver")) {
           countDupsCodeServer++;
         }
       }
     }
 
-    if (countDupsCodeServer > 1 || countDupsGwtDev > 1 || countDupsGwtUser > 1) {
+    if (countDupsCodeServer > 1 || countDupsGwtUser > 1) {
       out.println("\n\n More than one gwt jar has been found on the classpath. Clear console after fix.");
     }
 
@@ -283,13 +278,8 @@ public class ModuleClasspathProvider extends StandardClasspathProvider {
           out.println(m);
         }
 
-        if (countDupsGwtDev > 1 && entry.getPath().toString().toLowerCase().contains("gwt-dev")) {
-          String m = message.replace("jar", "gwt-dev.jar") + " ::: path=" + entry.getPath();
-          out.println(m);
-        }
-
         if (countDupsCodeServer > 1 && entry.getPath().toString().toLowerCase().contains("gwt-codeserver")) {
-          String m = message.replace("jar", "gwt-codeserver.jar") + " ::: path=" + entry.getPath();;
+          String m = message.replace("jar", "gwt-codeserver.jar") + " ::: path=" + entry.getPath();
           out.println(m);
         }
       }

--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/processors/SuperDevModeArgumentProcessor.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/processors/SuperDevModeArgumentProcessor.java
@@ -273,8 +273,7 @@ public class SuperDevModeArgumentProcessor implements ILaunchConfigurationProces
    * @param configuration the launch config.
    * @return an error string if things are wrong, or null if the module is valid.
    */
-  private String validateModule(IModule imodule, IJavaProject javaProject,
-      ILaunchConfiguration configuration) {
+  private String validateModule(IModule imodule, IJavaProject javaProject, ILaunchConfiguration configuration) {
     List<String> linkers = imodule.getAddLinkers();
     List<String> redirects = imodule.getSetConfigurationProperty("devModeRedirectEnabled");
     List<String> useSourceMaps = imodule.getSetConfigurationProperty("compiler.useSourceMaps");

--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/GWTSettingsTab.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/GWTSettingsTab.java
@@ -204,7 +204,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements ILaunchArgumentsCon
      * Change group title to the dev mode that is selected
      */
     public void setTitle() {
-      if (selectionBlock != null && selectionBlock.isSuperDevModeSelected()) {
+      if (selectionBlock != null && selectionBlock.isVisible() && selectionBlock.isSuperDevModeSelected()) {
         groupDevMode.setText(GROUP_TITLE_SUPERDEVMODE);
       } else {
         groupDevMode.setText(GROUP_TITLE_DEVMODE);
@@ -274,14 +274,29 @@ public class GWTSettingsTab extends JavaLaunchTab implements ILaunchArgumentsCon
     public void initializeFrom(ILaunchConfiguration config) throws CoreException {
       SWTUtilities.setText(groupSelection, GROUP_TITLE_SELECTION);
 
-      // switch the super dev mode on/off
+      // on load, set the radio to the correct selection
       boolean enabled = GWTLaunchConfiguration.getSuperDevModeEnabled(config);
+      setSdmRadioEnabled(enabled);
+    }
+
+    public void setSdmRadioEnabled(boolean enabled) {
       buttonSuperDevMode.setSelection(enabled);
       buttonDevMode.setSelection(!enabled);
     }
 
     public boolean isSuperDevModeSelected() {
       return buttonSuperDevMode.getSelection();
+    }
+
+    public void resetSdmRadio(ILaunchConfigurationWorkingCopy configuration) {
+      // reset the selection
+      setSdmRadioEnabled(true);
+      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration, true);
+
+      // reset the title
+      if (developmentModeBlock != null) {
+        developmentModeBlock.setTitle();
+      }
     }
 
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
@@ -303,23 +318,12 @@ public class GWTSettingsTab extends JavaLaunchTab implements ILaunchArgumentsCon
       updateArgumentProcessors(configuration);
     }
 
-    /**
-     * Reset to defaults. Note do not call updateLaunchConfigurationDialog();
-     */
-    public void setSdmEnabled(ILaunchConfigurationWorkingCopy configuration, boolean enable) {
-      // reset the selection
-      buttonSuperDevMode.setSelection(enable);
-      buttonDevMode.setSelection(!enable);
-      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration, enable);
-
-      // reset the title
-      if (developmentModeBlock != null) {
-        developmentModeBlock.setTitle();
-      }
-    }
-
     public void setVisible(boolean visible) {
       groupSelection.setVisible(visible);
+    }
+
+    public boolean isVisible() {
+      return groupSelection.isVisible();
     }
 
     /**
@@ -771,10 +775,15 @@ public class GWTSettingsTab extends JavaLaunchTab implements ILaunchArgumentsCon
     // can use super dev mode 2.5.0+ or 3+
     if (canSdkVersionUseSuperDevMode(version)) {
       selectionBlock.setVisible(true);
-      selectionBlock.setSdmEnabled(configuration, true);
     } else {
       selectionBlock.setVisible(false);
-      selectionBlock.setSdmEnabled(configuration, false);
+
+      // Turn off sdm
+      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration, false);
+    }
+
+    if (developmentModeBlock != null) {
+      developmentModeBlock.setTitle();
     }
   }
 

--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/GWTSettingsTab.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/GWTSettingsTab.java
@@ -88,8 +88,8 @@ import java.util.List;
  * For webapp launch configuration, tab where you specify GWT options.
  */
 @SuppressWarnings("restriction")
-public class GWTSettingsTab extends JavaLaunchTab implements
-    ILaunchArgumentsContainer.ArgumentsListener, UpdateLaunchConfigurationDialogBatcher.Listener {
+public class GWTSettingsTab extends JavaLaunchTab implements ILaunchArgumentsContainer.ArgumentsListener,
+    UpdateLaunchConfigurationDialogBatcher.Listener {
 
   /**
    * A factory that returns a GWT settings tab bound to an arguments tab.
@@ -114,8 +114,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     private final Text textDevModeCodeServerPort;
 
     public DevelopmentModeBlock(Composite parent) {
-      groupDevMode =
-          SWTFactory.createGroup(parent, GROUP_TITLE_DEVMODE, 2, 1, GridData.FILL_HORIZONTAL);
+      groupDevMode = SWTFactory.createGroup(parent, GROUP_TITLE_DEVMODE, 2, 1, GridData.FILL_HORIZONTAL);
 
       // Log level combo
       SWTFactory.createLabel(groupDevMode, "Log level:", 1);
@@ -176,17 +175,15 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     }
 
     public String getLogLevel() {
-      StructuredSelection logLevelSelection =
-          (StructuredSelection) comboDevModeLogLevelViewer.getSelection();
-      return logLevelSelection.getFirstElement() != null ? logLevelSelection.getFirstElement()
-          .toString() : LogLevelArgumentProcessor.DEFAULT_LOG_LEVEL;
+      StructuredSelection logLevelSelection = (StructuredSelection) comboDevModeLogLevelViewer.getSelection();
+      return logLevelSelection.getFirstElement() != null ? logLevelSelection.getFirstElement().toString()
+          : LogLevelArgumentProcessor.DEFAULT_LOG_LEVEL;
     }
 
     public void initializeFrom(ILaunchConfiguration config) throws CoreException {
       SWTUtilities.setText(groupDevMode, GROUP_TITLE_DEVMODE);
 
-      comboDevModeLogLevelViewer.setSelection(new StructuredSelection(GWTLaunchConfiguration
-          .getLogLevel(config)));
+      comboDevModeLogLevelViewer.setSelection(new StructuredSelection(GWTLaunchConfiguration.getLogLevel(config)));
       textDevModeCodeServerPort.setText(GWTLaunchConfiguration.getCodeServerPort(config));
       buttonDevModeAutoPort.setSelection(GWTLaunchConfiguration.getCodeServerPortAuto(config));
     }
@@ -194,16 +191,13 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
       // Log level arg
       GWTLaunchConfigurationWorkingCopy.setLogLevel(configuration, getLogLevel());
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(new LogLevelArgumentProcessor(),
-          configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new LogLevelArgumentProcessor(), configuration);
 
       // Dev Mode code server port
-      GWTLaunchConfigurationWorkingCopy.setDevModeCodeServerPort(configuration,
-          getDevModeCodeServerPort());
-      GWTLaunchConfigurationWorkingCopy.setDevModeCodeServerPortAuto(configuration,
-          getDevModeCodeServerPortAuto());
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(
-          new DevModeCodeServerPortArgumentProcessor(), configuration);
+      GWTLaunchConfigurationWorkingCopy.setDevModeCodeServerPort(configuration, getDevModeCodeServerPort());
+      GWTLaunchConfigurationWorkingCopy.setDevModeCodeServerPortAuto(configuration, getDevModeCodeServerPortAuto());
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new DevModeCodeServerPortArgumentProcessor(),
+          configuration);
     }
 
     /**
@@ -222,8 +216,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     }
 
     public void updateEnabledState() {
-      textDevModeCodeServerPort.setEnabled(!buttonDevModeAutoPort.getSelection()
-          && buttonDevModeAutoPort.getEnabled());
+      textDevModeCodeServerPort.setEnabled(!buttonDevModeAutoPort.getSelection() && buttonDevModeAutoPort.getEnabled());
     }
   }
 
@@ -236,8 +229,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     private final Group groupSelection;
 
     public SelectionBlock(Composite parent) {
-      groupSelection =
-          SWTFactory.createGroup(parent, GROUP_TITLE_SELECTION, 3, 1, GridData.FILL_HORIZONTAL);
+      groupSelection = SWTFactory.createGroup(parent, GROUP_TITLE_SELECTION, 3, 1, GridData.FILL_HORIZONTAL);
 
       buttonSuperDevMode = new Button(groupSelection, SWT.RADIO);
       buttonSuperDevMode.setText("Super Development Mode");
@@ -294,8 +286,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
 
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
       // super dev mode args
-      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration,
-          selectionBlock.isSuperDevModeSelected());
+      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration, selectionBlock.isSuperDevModeSelected());
 
       // Logic for determining Super Dev Mode is retrieved form working copy in
       // processors. So saving the Super Dev enabled here decouples processors.
@@ -304,8 +295,8 @@ public class GWTSettingsTab extends JavaLaunchTab implements
       try {
         configuration.doSave();
       } catch (CoreException e) {
-        MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(),
-            "Error saving project", "Please try hitting apply agian.");
+        MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(), "Error saving project",
+            "Please try hitting apply agian.");
       }
 
       // When changing between selections update all the launch config args
@@ -315,11 +306,11 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     /**
      * Reset to defaults. Note do not call updateLaunchConfigurationDialog();
      */
-    public void resetToDefaults(ILaunchConfigurationWorkingCopy configuration) {
+    public void setSdmEnabled(ILaunchConfigurationWorkingCopy configuration, boolean enable) {
       // reset the selection
-      buttonSuperDevMode.setSelection(true);
-      buttonDevMode.setSelection(false);
-      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration, true);
+      buttonSuperDevMode.setSelection(enable);
+      buttonDevMode.setSelection(!enable);
+      GWTLaunchConfigurationWorkingCopy.setSuperDevModeEnabled(configuration, enable);
 
       // reset the title
       if (developmentModeBlock != null) {
@@ -339,18 +330,14 @@ public class GWTSettingsTab extends JavaLaunchTab implements
      * instead of this below. Would need to figure out how to import.
      */
     public void updateArgumentProcessors(ILaunchConfigurationWorkingCopy configuration) {
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(new SuperDevModeArgumentProcessor(),
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new SuperDevModeArgumentProcessor(), configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new RemoteUiArgumentProcessor(), configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new LogLevelArgumentProcessor(), configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new DevModeCodeServerPortArgumentProcessor(),
           configuration);
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(new RemoteUiArgumentProcessor(),
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new StartupUrlArgumentProcessor(), configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new XStartOnFirstThreadArgumentProcessor(),
           configuration);
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(new LogLevelArgumentProcessor(),
-          configuration);
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(
-          new DevModeCodeServerPortArgumentProcessor(), configuration);
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(new StartupUrlArgumentProcessor(),
-          configuration);
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(
-          new XStartOnFirstThreadArgumentProcessor(), configuration);
     }
 
     /**
@@ -361,14 +348,13 @@ public class GWTSettingsTab extends JavaLaunchTab implements
         URL url = new URL(surl);
         PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(url);
       } catch (PartInitException ex) {
-        MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(),
-            "URL Error", "Error navigating to " + surl);
+        MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(), "URL Error",
+            "Error navigating to " + surl);
       } catch (MalformedURLException ex) {
-        MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(),
-            "URL Error", "Error navigating to " + surl);
+        MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(), "URL Error",
+            "Error navigating to " + surl);
       }
     }
-
   }
 
   /**
@@ -398,10 +384,8 @@ public class GWTSettingsTab extends JavaLaunchTab implements
           try {
             IJavaProject javaProject = getJavaProject();
             if (javaProject == null) {
-              MessageDialog.openError(
-                  Workbench.getInstance().getActiveWorkbenchWindow().getShell(),
-                  "No project found",
-                  "Please make sure that this launch configuration has a valid project assigned.");
+              MessageDialog.openError(Workbench.getInstance().getActiveWorkbenchWindow().getShell(),
+                  "No project found", "Please make sure that this launch configuration has a valid project assigned.");
               return;
             }
 
@@ -436,8 +420,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
 
     public void initializeFrom(ILaunchConfiguration config) throws CoreException {
       boolean hasNoServerArg =
-          NoServerArgumentProcessor.hasNoServerArg(LaunchConfigurationProcessorUtilities
-              .parseProgramArgs(config));
+          NoServerArgumentProcessor.hasNoServerArg(LaunchConfigurationProcessorUtilities.parseProgramArgs(config));
       boolean showStartupUrl =
           GwtLaunchConfigurationProcessorUtilities.isGwtShell(config)
               || GwtLaunchConfigurationProcessorUtilities.isHostedMode(config)
@@ -452,11 +435,10 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     public void performApply(ILaunchConfigurationWorkingCopy configuration) {
       // Save the startup URL
       GWTLaunchConfigurationWorkingCopy.setStartupUrl(configuration, getUrl().trim());
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(new StartupUrlArgumentProcessor(),
-          configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new StartupUrlArgumentProcessor(), configuration);
 
-      LaunchConfigurationProcessorUtilities.updateViaProcessor(
-          new XStartOnFirstThreadArgumentProcessor(), configuration);
+      LaunchConfigurationProcessorUtilities.updateViaProcessor(new XStartOnFirstThreadArgumentProcessor(),
+          configuration);
     }
   }
 
@@ -557,8 +539,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
 
     if (showPerformGwtCompileSetting) {
       createVerticalSpacer(comp, 1);
-      performGwtCompileButton =
-          SWTFactory.createCheckButton(comp, "Perform GWT compile", null, true, 1);
+      performGwtCompileButton = SWTFactory.createCheckButton(comp, "Perform GWT compile", null, true, 1);
       performGwtCompileButton.addSelectionListener(new SelectionAdapter() {
         @Override
         public void widgetSelected(SelectionEvent e) {
@@ -590,8 +571,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
   public void doPerformApply(ILaunchConfigurationWorkingCopy configuration) {
     // Save the entry point modules - save first!
     persistModules(configuration, entryPointModulesSelectionBlock.getModules());
-    LaunchConfigurationProcessorUtilities.updateViaProcessor(new ModuleArgumentProcessor(),
-        configuration);
+    LaunchConfigurationProcessorUtilities.updateViaProcessor(new ModuleArgumentProcessor(), configuration);
     if (selectionBlock != null) {
       selectionBlock.performApply(configuration);
     }
@@ -606,8 +586,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
 
     if (performGwtCompileButton != null) {
       LaunchConfigurationAttributeUtilities.set(configuration,
-          SpeedTracerLaunchConfiguration.Attribute.PERFORM_GWT_COMPILE,
-          performGwtCompileButton.getSelection());
+          SpeedTracerLaunchConfiguration.Attribute.PERFORM_GWT_COMPILE, performGwtCompileButton.getSelection());
     }
 
     enableSuperDevModeSelection(configuration);
@@ -654,8 +633,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
           // set of defined entry point modules (specified in project
           // properties).
           IProject project = javaProject.getProject();
-          entryPointModulesSelectionBlock.setDefaultModules(ModuleArgumentProcessor
-              .getDefaultModules(project, config));
+          entryPointModulesSelectionBlock.setDefaultModules(ModuleArgumentProcessor.getDefaultModules(project, config));
 
           // Initialize the selected set of entry point modules
           List<String> launchConfigModules = GWTLaunchConfiguration.getEntryPointModules(config);
@@ -704,8 +682,7 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     }
 
     try {
-      String startupUrl =
-          StartupUrlArgumentProcessor.getStartupUrl(args, getCurrentLaunchConfiguration());
+      String startupUrl = StartupUrlArgumentProcessor.getStartupUrl(args, getCurrentLaunchConfiguration());
       GWTLaunchConfigurationWorkingCopy.setStartupUrl(config, startupUrl);
     } catch (CoreException e) {
       GWTPluginLog.logError(e, "Could not persist startup URL");
@@ -748,16 +725,14 @@ public class GWTSettingsTab extends JavaLaunchTab implements
   protected void maybeGrayControls(IJavaProject javaProject) {
     boolean isGWTProject = javaProject != null && GWTNature.isGWTProject(javaProject.getProject());
     String message =
-        isGWTProject ? null
-            : "GWT is not enabled for this project. You can enable it in the project's properties.";
+        isGWTProject ? null : "GWT is not enabled for this project. You can enable it in the project's properties.";
 
     setMessage(message);
     SWTUtilities.setEnabledRecursive(comp, isGWTProject);
   }
 
   protected void persistModules(ILaunchConfigurationWorkingCopy configuration, List<String> modules) {
-    GWTLaunchConfigurationWorkingCopy.setEntryPointModules(configuration, modules,
-        Collections.<String>emptyList());
+    GWTLaunchConfigurationWorkingCopy.setEntryPointModules(configuration, modules, Collections.<String>emptyList());
   }
 
   protected void registerProgramArgsListener(ILaunchArgumentsContainer argsContainer) {
@@ -796,17 +771,17 @@ public class GWTSettingsTab extends JavaLaunchTab implements
     // can use super dev mode 2.5.0+ or 3+
     if (canSdkVersionUseSuperDevMode(version)) {
       selectionBlock.setVisible(true);
+      selectionBlock.setSdmEnabled(configuration, true);
     } else {
       selectionBlock.setVisible(false);
-      selectionBlock.resetToDefaults(configuration);
+      selectionBlock.setSdmEnabled(configuration, false);
     }
   }
 
   private IProject getProject() throws CoreException {
     IJavaProject javaProject = getJavaProject();
     if (javaProject == null || !javaProject.exists()) {
-      throw new CoreException(new Status(IStatus.ERROR, GWTPlugin.PLUGIN_ID,
-          "Could not get a valid Java project"));
+      throw new CoreException(new Status(IStatus.ERROR, GWTPlugin.PLUGIN_ID, "Could not get a valid Java project"));
     }
     return javaProject.getProject();
   }

--- a/plugins/com.google.gwt.eclipse.wtp/src/com/google/gwt/eclipse/wtp/GwtWtpPlugin.java
+++ b/plugins/com.google.gwt.eclipse.wtp/src/com/google/gwt/eclipse/wtp/GwtWtpPlugin.java
@@ -309,7 +309,31 @@ public final class GwtWtpPlugin extends AbstractUIPlugin {
 
     RuntimeProcess serverRuntimeProcess = (RuntimeProcess) event.getSource();
     ILaunch serverLaunch = serverRuntimeProcess.getLaunch();
-    if (serverLaunch == null) {
+    ILaunchConfiguration launchConfig = serverLaunch.getLaunchConfiguration();
+
+    IServer server = null;
+    try {
+      server = ServerUtil.getServer(launchConfig);
+    } catch (CoreException e) {
+      logError("posiblyLaunchGwtSuperDevModeCodeServer: Could get the WTP server.", e);
+      return;
+    }
+
+    if (server == null) {
+      logMessage("posiblyLaunchGwtSuperDevModeCodeServer: No WTP server found.");
+      return;
+    }
+
+    IProject project = getProject(server);
+    if (project == null) {
+      logMessage("posiblyLaunchGwtSuperDevModeCodeServer: Couldn't find project.");
+      return;
+    }
+    
+    // If the sync is off, ignore stopping the server
+    if (GWTProjectProperties.getFacetSyncCodeServer(project) != null
+        && GWTProjectProperties.getFacetSyncCodeServer(project) == false) {
+      logMessage("posiblyLaunchGwtSuperDevModeCodeServer: GWT Facet project properties, the code server sync is off.");
       return;
     }
 
@@ -344,7 +368,7 @@ public final class GwtWtpPlugin extends AbstractUIPlugin {
       }
 
       for (ILaunch launch : launches) {
-        ILaunchConfiguration launchConfig = launch.getLaunchConfiguration();
+        launchConfig = launch.getLaunchConfiguration();
         String launcherId = launchConfig.getAttribute(GWTLaunchConstants.SUPERDEVMODE_LAUNCH_ID, (String) null);
         // If its the sdm code server
         if (sdmcodeServerType.equals(serverType)) {

--- a/plugins/com.google.gwt.eclipse.wtp/src/com/google/gwt/eclipse/wtp/properties/ui/GwtFacetComposite.java
+++ b/plugins/com.google.gwt.eclipse.wtp/src/com/google/gwt/eclipse/wtp/properties/ui/GwtFacetComposite.java
@@ -1,12 +1,13 @@
 package com.google.gwt.eclipse.wtp.properties.ui;
 
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 
 public class GwtFacetComposite extends Composite {
 
@@ -20,12 +21,16 @@ public class GwtFacetComposite extends Composite {
    */
   public GwtFacetComposite(Composite parent, int style) {
     super(parent, style);
-    setLayout(new GridLayout(1, false));
+    setLayout(new FillLayout(SWT.HORIZONTAL));
+    
+    Composite composite = new Composite(this, SWT.NONE);
+    composite.setLayout(new GridLayout(1, false));
 
-    Label lblGwtFacet = new Label(this, SWT.NONE);
+    
+    Label lblGwtFacet = new Label(composite, SWT.NONE);
     lblGwtFacet.setText("Super Development Mode");
 
-    btnAutoStartThe = new Button(this, SWT.CHECK);
+    btnAutoStartThe = new Button(composite, SWT.CHECK);
     btnAutoStartThe.setSelection(true);
     btnAutoStartThe.addSelectionListener(new SelectionAdapter() {
       @Override


### PR DESCRIPTION
This should fix legacy jar issues. 
This should fix when using older SDK and SDM gets started instead. 
This will warn users when two gwt-user.jars, gwt-dev and gwt-codeserver.jar are on the classpath. 
This fixes wtp server running/stopping sync, when stopping sdm it won't stop the server when facet sync off. 
This will fix the background color of the facet settings. 