### PR TITLE
Use the code server port attribute instead of the classic dev mode port

### DIFF
--- a/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/tabs/GwtSuperDevModeCodeServerSettingsTab.java
+++ b/plugins/com.google.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/tabs/GwtSuperDevModeCodeServerSettingsTab.java
@@ -180,7 +180,7 @@ public class GwtSuperDevModeCodeServerSettingsTab extends JavaLaunchTab implemen
 
       logLevelComboViewer.setSelection(new StructuredSelection(GWTLaunchConfiguration.getLogLevel(config)));
 
-      portServerText.setText(GWTLaunchConfiguration.getClassicDevModeCodeServerPort(config));
+      portServerText.setText(GWTLaunchConfiguration.getSdmCodeServerPort(config));
 
       portAutoSelectionButton.setSelection(GWTLaunchConfiguration.getClassicDevModeCodeServerPortAuto(config));
     }


### PR DESCRIPTION
Changing the code server port currently has no effect. Every time you open the configuration dialog the value is reset. @wbabachan mentioned this in https://github.com/gwt-plugins/gwt-eclipse-plugin/pull/144#issuecomment-232670296.

The problem is that the value is read from the wrong launch attribute. It uses the classic dev mode port instead of the super dev mode port. This pull request fixes that problem.