### PR TITLE
Fixes #168 Corrected package name.

### DIFF
--- a/plugins/com.gwtplugins.gwt.eclipse.core/plugin.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/plugin.xml
@@ -299,7 +299,7 @@
    <extension
          point="org.eclipse.debug.ui.launchConfigurationTabGroups">
       <launchConfigurationTabGroup
-            class="com.google.gwt.eclipse.core.launch.ui.groups.GWTJUnitTabGroup"
+            class="com.google.gwt.eclipse.core.launch.ui.tab_groups.GWTJUnitTabGroup"
             helpContextId="org.eclipse.jdt.junit.junit_tab_group"
             id="com.gwtplugins.gwt.eclipse.core.launch.gwtJUnitTabGroup"
             type="com.gwtplugins.gwt.eclipse.core.launch.gwtJUnit">

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
@@ -31,7 +31,7 @@
               <url>https://goo.gl/TysXZl</url> 
               <unpack>true</unpack>
               <overwrite>true</overwrite>
-              <outputFileName>${basedir}/gwt-2.8.1.zip</outputFileName>
+              <outputFileName>gwt-2.8.1.zip</outputFileName>
               <outputDirectory>${basedir}</outputDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
Fixes #168 Corrected package name.
Also updated the path in sdkbundle.gwt28 as it was not building.

I have tested this locally and it is not working as expected and the GWT Junit tests can be viewed in eclipse
![image](https://user-images.githubusercontent.com/14773418/35098860-bb9d4042-fc4d-11e7-8052-96663bd08444.png)
