### PR TITLE
Added workaround for performance issue: retrieving the GWT SDK versio…

### DIFF
--- a/eclipse/mars/gwt-eclipse-mars.target
+++ b/eclipse/mars/gwt-eclipse-mars.target
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GWT Eclipse Plugin Mars" sequenceNumber="1521650710">
+<target name="GWT Eclipse Plugin Mars" sequenceNumber="1533891458">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="2.0.0.v20180130-0820"/>
+      <unit id="org.eclipse.license.feature.group" version="2.0.1.v20180423-1114"/>
       <repository location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -43,7 +43,7 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.google.cloud.tools.eclipse.suite.feature.feature.group" version="1.6.0.201803071812"/>
+      <unit id="com.google.cloud.tools.eclipse.suite.feature.feature.group" version="1.7.1.201807071456"/>
       <repository location="https://dl.google.com/eclipse/google-cloud-eclipse/stable/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/eclipse/neon/gwt-eclipse-neon.target
+++ b/eclipse/neon/gwt-eclipse-neon.target
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GWT Eclipse Plugin Neon" sequenceNumber="1521650840">
+<target name="GWT Eclipse Plugin Neon" sequenceNumber="1533891509">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="2.0.0.v20180130-0820"/>
+      <unit id="org.eclipse.license.feature.group" version="2.0.1.v20180423-1114"/>
       <repository location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -23,21 +23,21 @@
       <repository location="http://download.eclipse.org/releases/neon"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201608191717"/>
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201702270442"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.0.v201609072018"/>
-      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201606081655"/>
-      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.8.0.v201605251556"/>
-      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.8.0.v201608191717"/>
-      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.8.1.v201609072018"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.2.v201702270442"/>
+      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201703062119"/>
+      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.8.0.v201701262139"/>
+      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.8.0.v201702270442"/>
+      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.8.2.v201702270442"/>
       <unit id="org.eclipse.jst.server_adapters.feature.feature.group" version="3.2.400.v201606081655"/>
       <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.3.501.v201609071751"/>
       <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.300.v201606081655"/>
-      <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.500.v201606081655"/>
+      <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.500.v201703062119"/>
       <unit id="org.eclipse.jst.server_adapters.ext.sdk.feature.feature.group" version="3.3.501.v201609071751"/>
-      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201605201456"/>
+      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201610211907"/>
       <repository location="http://download.eclipse.org/webtools/repository/neon/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -45,7 +45,7 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.google.cloud.tools.eclipse.suite.feature.feature.group" version="1.6.0.201803071812"/>
+      <unit id="com.google.cloud.tools.eclipse.suite.feature.feature.group" version="1.7.1.201807071456"/>
       <repository location="https://dl.google.com/eclipse/google-cloud-eclipse/stable/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/eclipse/oxygen/gwt-eclipse-oxygen.target
+++ b/eclipse/oxygen/gwt-eclipse-oxygen.target
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GWT Eclipse Plugin for Oxygen" sequenceNumber="1501537180">
+<target name="GWT Eclipse Plugin for Oxygen" sequenceNumber="1533891537">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
+      <unit id="org.eclipse.license.feature.group" version="2.0.1.v20180423-1114"/>
       <repository location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/properties/GWTProjectProperties.java
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/properties/GWTProjectProperties.java
@@ -51,6 +51,8 @@ public final class GWTProjectProperties {
 
   private static final String SYNC_CODESERVER_RUNNING =  "gwtSyncCodeServer";
 
+  private static final String FIXED_GWT_SDK_VERSION =  "gwtFixedSdkVersion";
+
   /**
    * Returns the default set of entry point modules for a project. This set
    * contains all modules defined in source (.gwt.xml) in the project.
@@ -143,6 +145,17 @@ public final class GWTProjectProperties {
     String valueStr = prefs.get(SYNC_CODESERVER_RUNNING, "true");
     Boolean b = Boolean.valueOf(valueStr);
     return b;
+  }
+
+  public static void setFixedGwtSdkVersion(IProject project, String version) throws BackingStoreException {
+    IEclipsePreferences prefs = getProjectProperties(project);
+    prefs.put(FIXED_GWT_SDK_VERSION, version);
+    prefs.flush();
+  }
+
+  public static String getFixedGwtSdkVersion(IProject project) {
+    IEclipsePreferences prefs = getProjectProperties(project);
+    return prefs.get(FIXED_GWT_SDK_VERSION, "");
   }
 
   public static void setEntryPointModules(IProject project, List<String> modules)

--- a/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/properties/ui/GWTProjectPropertyPage.java
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/properties/ui/GWTProjectPropertyPage.java
@@ -58,6 +58,8 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
@@ -99,6 +101,8 @@ public class GWTProjectPropertyPage extends AbstractProjectPropertyPage {
 
   private boolean useGWT;
 
+  private Text gwtFixedSdkVersionTextField;
+
   private Button useGWTCheckbox;
 
   public GWTProjectPropertyPage() {
@@ -137,6 +141,7 @@ public class GWTProjectPropertyPage extends AbstractProjectPropertyPage {
 
     if (useGWT) {
       saveChangesToEntryPointModules();
+      saveFixedGwtSdkVersion();
     }
   }
 
@@ -269,6 +274,21 @@ public class GWTProjectPropertyPage extends AbstractProjectPropertyPage {
         return GWTPreferences.getSdkManager();
       }
     };
+
+    Group groupFixedSdk = SWTFactory.createGroup(parent, "Fixed GWT SDK Version", 1, 1, GridData.FILL_HORIZONTAL);
+
+    Label label = new Label(groupFixedSdk, SWT.NULL);
+    label.setText("Version: ");
+
+    gwtFixedSdkVersionTextField = new Text(groupFixedSdk, SWT.SINGLE | SWT.BORDER);
+    GridData gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+    gridData.horizontalSpan = 3;
+    gwtFixedSdkVersionTextField.setLayoutData(gridData);
+
+    String version = GWTProjectProperties.getFixedGwtSdkVersion(getProject());
+    gwtFixedSdkVersionTextField.setText(version);
+    gwtFixedSdkVersionTextField.setToolTipText("This is a workaround for a performance issue in large projects."
+        + " Enter the version string of the SDK to use with this project, for example '2.7.0'.");
   }
 
   private void fieldChanged() {
@@ -359,6 +379,10 @@ public class GWTProjectPropertyPage extends AbstractProjectPropertyPage {
         GWTPluginLog.logError(e, "Could not open GWT Java editor on {0}", editorRef.getTitleToolTip());
       }
     }
+  }
+
+  private void saveFixedGwtSdkVersion() throws BackingStoreException {
+    GWTProjectProperties.setFixedGwtSdkVersion(getProject(), gwtFixedSdkVersionTextField.getText());
   }
 
   private void saveChangesToEntryPointModules() throws BackingStoreException {

--- a/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/runtime/GwtSdk.java
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/runtime/GwtSdk.java
@@ -24,6 +24,7 @@ import com.google.gwt.eclipse.core.GWTPlugin;
 import com.google.gwt.eclipse.core.GWTPluginLog;
 import com.google.gwt.eclipse.core.launch.processors.GwtLaunchConfigurationProcessorUtilities;
 import com.google.gwt.eclipse.core.preferences.GWTPreferences;
+import com.google.gwt.eclipse.core.properties.GWTProjectProperties;
 import com.google.gwt.eclipse.core.util.Util;
 
 import org.eclipse.core.resources.IProject;
@@ -86,6 +87,20 @@ public abstract class GwtSdk extends AbstractSdk {
     protected ProjectBoundSdk(IJavaProject javaProject) {
       super("", null);
       this.javaProject = javaProject;
+    }
+
+    @Override
+    public String getVersion() {
+      // Retrieving the version of a ProjectBoundSdk via the classloader is SLOW!
+      // This is a workaround that skips the whole procedure if the version string can be found
+      // in the properties of the project instead.
+      String version = GWTProjectProperties.getFixedGwtSdkVersion(javaProject.getProject());
+      if (version == null || version.isEmpty()) {
+        // TODO: Maybe output a warning message here that points out the slow behaviour due to
+        // not having configured the property?
+        return super.getVersion();
+      }
+      return SdkUtils.cleanupVersion(version);
     }
 
     /**


### PR DESCRIPTION
Added workaround for performance issue: retrieving the GWT SDK version of `ProjectBoundSdk` via classloader is slow, so skip this step if a fixed version string is set in the project properties.
A new section for a "Fixed GWT SDK version" has been added to the project properties, in order to also configure the value via GUI and not just via the .settings file.

The issue is described in gwt-plugins/gwt-eclipse-plugin#383

This is a workaround that avoids the issue, rather than fixing it. So feel free to suggest changes or come up with a different approach.