### PR TITLE
Switched off analytics ping and updatenotification

### DIFF
--- a/plugins/com.gwtplugins.gdt.eclipse.suite/src/com/google/gdt/eclipse/suite/preferences/GdtPreferences.java
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite/src/com/google/gdt/eclipse/suite/preferences/GdtPreferences.java
@@ -136,11 +136,11 @@ public final class GdtPreferences {
   private static final String VERSION_FOR_LAST_FORCED_REBUILD_PREFIX = "versionForLastForcedRebuild_";
 
   public static boolean areUpdateNotificationsEnabled() {
-    return getConfigurationPreferences().getBoolean(UPDATE_NOTIFICATIONS, true);
+    return getConfigurationPreferences().getBoolean(UPDATE_NOTIFICATIONS, false);
   }
 
   public static boolean getCaptureAnalytics() {
-    return getConfigurationPreferences().getBoolean(CAPTURE_ANALYTICS, true);
+    return getConfigurationPreferences().getBoolean(CAPTURE_ANALYTICS, false);
   }
 
   public static List<String> getAddedNewWizardActionsForPerspective(String perspectiveId) {


### PR DESCRIPTION
There are 2 reasons for switching this of.
1. It's illegal in the EU to send user data without prior permission.
2. Google does no longer support this project in any way. So why should we send data to them?