### PR TITLE
Update version for 4.0.1 development work after release

### DIFF
--- a/eclipse/2022-09/pom.xml
+++ b/eclipse/2022-09/pom.xml
@@ -6,7 +6,7 @@
  <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>gwt-eclipse-2022-09</artifactId>

--- a/eclipse/ide-target-platform/pom.xml
+++ b/eclipse/ide-target-platform/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>ide-target-platform.repo</artifactId>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt27.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt27.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/features/com.gwtplugins.eclipse.suite.v3.feature/feature.xml
+++ b/features/com.gwtplugins.eclipse.suite.v3.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.gwtplugins.eclipse.suite.v3.feature"
       label="%featureName"
-      version="4.0.0.qualifier"
+      version="4.0.1.qualifier"
       provider-name="%providerName"
       plugin="com.gwtplugins.gdt.eclipse.suite">
 
@@ -105,84 +105,84 @@
          id="com.gwtplugins.gdt.eclipse.apiclientlib"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gwt.eclipse.core"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gdt.eclipse.maven"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gdt.eclipse.platform"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gdt.eclipse.suite"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gdt.eclipse.suite.update"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gwt.eclipse.core"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gwt.eclipse.oophm"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gwt.eclipse.wtp"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gwt.eclipse.wtp.maven"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gdt.eclipse.core"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
    <plugin
          id="com.gwtplugins.gwt.eclipse.gss"
          download-size="0"
          install-size="0"
-         version="4.0.0.qualifier"
+         version="4.0.1.qualifier"
          unpack="false"/>
 
 </feature>

--- a/features/com.gwtplugins.eclipse.suite.v3.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.suite.v3.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/plugins/com.gwtplugins.gcp.eclipse.testing/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gcp.eclipse.testing/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gcp.eclipse.testing;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gcp.eclipse.testing
 Require-Bundle: 
  com.gwtplugins.gdt.eclipse.core,

--- a/plugins/com.gwtplugins.gcp.eclipse.testing/pom.xml
+++ b/plugins/com.gwtplugins.gcp.eclipse.testing/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   
   <artifactId>com.gwtplugins.gcp.eclipse.testing</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gdt.eclipse.apiclientlib/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.apiclientlib/META-INF/MANIFEST.MF
@@ -33,7 +33,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.apiclientlib;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.api.client.auth.oauth2,
  com.google.api.client.googleapis,
  com.google.api.client.googleapis.auth.clientlogin,

--- a/plugins/com.gwtplugins.gdt.eclipse.apiclientlib/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.apiclientlib/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   

--- a/plugins/com.gwtplugins.gdt.eclipse.core.test/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.core.test/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-Name: Test Fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.core.test
 Bundle-Vendor: GWT Project
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Fragment-Host: com.gwtplugins.gdt.eclipse.core
 Require-Bundle: org.junit

--- a/plugins/com.gwtplugins.gdt.eclipse.core.test/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.core.test/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gdt.eclipse.core.test</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gdt.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.core/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.core;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.base.internal,

--- a/plugins/com.gwtplugins.gdt.eclipse.core/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.core/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gdt.eclipse.core</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
 </project>

--- a/plugins/com.gwtplugins.gdt.eclipse.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.maven/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.maven;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gdt.eclipse.maven,
  com.google.gdt.eclipse.maven.configurators,
  com.google.gdt.eclipse.maven.launch,

--- a/plugins/com.gwtplugins.gdt.eclipse.maven/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.maven/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gdt.eclipse.maven</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gdt.eclipse.platform/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.platform/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.platform;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gdt.eclipse.platform.debug.ui,
  com.google.gdt.eclipse.platform.jdt.dom,
  com.google.gdt.eclipse.platform.jdt.formatter,

--- a/plugins/com.gwtplugins.gdt.eclipse.platform/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.platform/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   
   
   <artifactId>com.gwtplugins.gdt.eclipse.platform</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
 </project>

--- a/plugins/com.gwtplugins.gdt.eclipse.suite.test/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Test Fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.suite.test
 Bundle-Vendor: GWT Project
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Fragment-Host: com.gwtplugins.gdt.eclipse.suite
 Require-Bundle: com.gwtplugins.gcp.eclipse.testing,
  com.gwtplugins.gwt.eclipse.testing,

--- a/plugins/com.gwtplugins.gdt.eclipse.suite.test/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite.test/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   
   <artifactId>com.gwtplugins.gdt.eclipse.suite.test</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/plugins/com.gwtplugins.gdt.eclipse.suite.update/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite.update/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: GWT Development Tools Suite Plugin
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.suite.update;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: GWT Eclipse Plugin
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gdt.eclipse.suite.update,
  com.google.gdt.eclipse.suite.update.builders,
  com.google.gdt.eclipse.suite.update.ui,

--- a/plugins/com.gwtplugins.gdt.eclipse.suite.update/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite.update/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gdt.eclipse.suite.update</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gdt.eclipse.suite/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gdt.eclipse.suite;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gdt.eclipse.suite,
  com.google.gdt.eclipse.suite.actions,
  com.google.gdt.eclipse.suite.launch,

--- a/plugins/com.gwtplugins.gdt.eclipse.suite/pom.xml
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gdt.eclipse.suite</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gwt.eclipse.core.test/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.core.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: GWT Core Test Fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.core.test
 Bundle-Vendor: GWT Project
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Fragment-Host: com.gwtplugins.gwt.eclipse.core
 Require-Bundle: com.gwtplugins.gcp.eclipse.testing,
  com.gwtplugins.gwt.eclipse.testing,

--- a/plugins/com.gwtplugins.gwt.eclipse.core.test/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.core.test/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
 
   <artifactId>com.gwtplugins.gwt.eclipse.core.test</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/plugins/com.gwtplugins.gwt.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.core;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gwt.eclipse.core,
  com.google.gwt.eclipse.core.actions,
  com.google.gwt.eclipse.core.applications,

--- a/plugins/com.gwtplugins.gwt.eclipse.core/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gwt.eclipse.core</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/com.gwtplugins.gwt.eclipse.gss/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.gss/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GWT GSS Tools
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.gss;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Bundle-Activator: com.gwtplugins.gwt.eclipse.gss.Activator
 Bundle-Vendor: GWT Eclipse Plugin
 Require-Bundle: org.eclipse.ui,

--- a/plugins/com.gwtplugins.gwt.eclipse.gss/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.gss/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/plugins/com.gwtplugins.gwt.eclipse.oophm.test/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.oophm.test/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: GWT Out-Of-Process Hosted Mode Plugin Test Fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.oophm.test
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Fragment-Host: com.gwtplugins.gwt.eclipse.oophm
 Require-Bundle: org.junit

--- a/plugins/com.gwtplugins.gwt.eclipse.oophm.test/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.oophm.test/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gwt.eclipse.oophm.test</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gwt.eclipse.oophm/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.oophm/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Name: %pluginName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.oophm;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gwt.eclipse.oophm,
  com.google.gwt.eclipse.oophm.breadcrumbs,
  com.google.gwt.eclipse.oophm.devmode,

--- a/plugins/com.gwtplugins.gwt.eclipse.oophm/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.oophm/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gwt.eclipse.oophm</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt27/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt27/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/plugins/com.gwtplugins.gwt.eclipse.testing/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.testing/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: GWT Testing Plug-in
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.testing;singleton:=true
 Bundle-Vendor: GWT Project
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Export-Package: com.google.gwt.eclipse.testing
 Require-Bundle: com.gwtplugins.gcp.eclipse.testing,
  com.gwtplugins.gdt.eclipse.core,

--- a/plugins/com.gwtplugins.gwt.eclipse.testing/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.testing/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gwt.eclipse.testing</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp.maven.test/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp.maven.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: GWT Eclipse Plugin SWTBot Test Fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.wtp.maven.test
 Bundle-Vendor: GWT Project
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Fragment-Host: com.gwtplugins.gwt.eclipse.core
 Require-Bundle: com.gwtplugins.gwt.eclipse.testing,
  org.junit

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp.maven.test/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp.maven.test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp.maven/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.wtp.maven;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: com.google.gwt.eclipse.wtp.maven.GwtMavenPlugin
 Bundle-Vendor: %providerName

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp.maven/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp.maven/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gwt.eclipse.wtp.maven</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp.test/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: GWT Eclipse Plugin SWTBot Test Fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.wtp.test
 Bundle-Vendor: GWT Project
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Fragment-Host: com.gwtplugins.gwt.eclipse.core
 Require-Bundle: com.gwtplugins.gwt.eclipse.testing,
  org.junit,

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp.test/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp.test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.wtp;singleton:=true
-Bundle-Version: 4.0.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: com.google.gwt.eclipse.wtp.GwtWtpPlugin
 Bundle-Vendor: %providerName

--- a/plugins/com.gwtplugins.gwt.eclipse.wtp/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.wtp/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <artifactId>com.gwtplugins.gwt.eclipse.wtp</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.gwtplugins.eclipse</groupId>
   <artifactId>trunk</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.gwtplugins.eclipse</groupId>
     <artifactId>trunk</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 


### PR DESCRIPTION
Generated via org.eclipse.tycho:tycho-versions-plugin:set-version.

At least for the time being, I propose we push this to main, but we could just as easily start a release/4.0 branch for 4.0.1 commits, and have 4.1.0 work land on main.