### PR TITLE
Sign created artifacts, document updated processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ The Google Cloud Tools team has put a significant amount of effort in helping br
 
 * [Google Cloud Tools](https://cloud.google.com/)
 
-### Sencha
-Sencha provides man power to help update the plugin and the build server which automates the build. 
-
-  [![Sencha GXT](http://cdn.sencha.com/img/gwt-eclipse-plugin-banner.png)](https://www.sencha.com/products/gxt/)
-
-
 ## Quality
 * This plugin is Beta Quality. 
 
@@ -61,17 +55,17 @@ The Eclipse repositories for this plugin.
 ### Production
 Release update site. 
 
-* [http://storage.googleapis.com/gwt-eclipse-plugin/v3/release](http://storage.googleapis.com/gwt-eclipse-plugin/v3/release)
+* [Eclipse Marketplace entry for the GWT Plugin](https://marketplace.eclipse.org/content/gwt-plugin)
+* [Update sites for the GWT Plugin](https://plugins.gwtproject.org/eclipse/gwt-eclipse-plugin/)
 
 ### Production Zip
-Download the repo in a zip file. 
-
-* [http://storage.googleapis.com/gwt-eclipse-plugin/v3/downloads/repo-3.0.0.zip](http://storage.googleapis.com/gwt-eclipse-plugin/v3/downloads/repo-3.0.0.zip)
+Download the repo in a zip file from the latest release at the
+[releases page](https://github.com/gwt-plugins/gwt-eclipse-plugin/releases/).
 
 ### Staging
-Staging repo for testing before production release.
+The staging repository is also at plugins.gwtproject.org, under the `nightly` version:
 
-* [http://storage.googleapis.com/gwt-eclipse-plugin/v3/snapshot](http://storage.googleapis.com/gwt-eclipse-plugin/v3/snapshot)
+* [https://plugins.gwtproject.org/eclipse/gwt-eclipse-plugin/](nightly)
 
 
 ## Development 
@@ -90,16 +84,27 @@ The target defintion build is based off of the Google Cloud Tools. Follow their 
 * Note: The targets will have to be updated by setting the targets. This will regenerate the Eclipse target files.  
 
 ### Build
-Sencha has provided an internal build agent to build. 
-[Sencha Eclipse Build](https://teamcity.sencha.com/viewType.html?buildTypeId=Gxt3_Gwt_GwtEclipsePlugin)
+To build, Apache Maven and Java 17 are required. Invoke `mvn verify` to build and test. The resulting
+update site can be found in `repo/target/repository` for local deployment and testing.
 
-* `mvn clean install`
+### Release
+Creating a release requires signing artifacts. Set the following environment variables before running
+`mvn verify`:
+ * `SIGN_KEYSTORE` - Path to a pkcs12 keystore that contains a key to use to sign this release
+ * `SIGN_STOREPASS` - Passphrase for the keystore
+ * `SIGN_ALIAS` - Alias of the key to use to sign the release
+ * `SIGN_KEYPASS` - Passphrase for the key
+ * `SIGN_TSA` - URL of a Time stamp authority to use to sign this release
+ 
+ At this time, releases are performed manually. The releases deployed to the marketplace will be signed
+ with the certificate for `plugins.gwtproject.org`.
 
 ### Deploy
-Google storage write permissions are needed to deploy. 
-
-* `sh ./build-deploy-release.sh` - deploy production version
-* `sh ./build-deploy-snapshot.sh` - deploy snapshot version
+Releases are uploaded as zips to the [release](https://github.com/gwt-plugins/gwt-eclipse-plugin/releases/)
+part of the Github project page, and also deployed at
+https://plugins.gwtproject.org/eclipse/gwt-eclipse-plugin as Eclipse update sites. Releases will be
+added to the [GWT-Plugin](https://marketplace.eclipse.org/content/gwt-plugin) page on the Eclipse
+Marketplace.
 
 ### Testing
 There are a couple of archetypes that are used to test. 

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,41 @@
         <module>eclipse/ide-target-platform</module>
       </modules>
     </profile>
-
+    <profile>
+      <!-- We only sign the jars when the keystore has been provided in the environment -->
+      <id>sign-jars</id>
+      <activation>
+        <file>
+          <exists>${env.SIGN_KEYSTORE}</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jarsigner-plugin</artifactId>
+            <version>3.0.0</version>
+            <configuration>
+              <keystore>${env.SIGN_KEYSTORE}</keystore>
+              <storepass>${env.SIGN_STOREPASS}</storepass>
+              <alias>${env.SIGN_ALIAS}</alias>
+              <keypass>${env.SIGN_KEYPASS}</keypass>
+              <storetype>${env.SIGN_STORETYPE}</storetype>
+              <tsa>${env.SIGN_TSA}</tsa>
+              <verbose>true</verbose>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>teamcity</id>
       <properties>


### PR DESCRIPTION
Deployed manually for testing at `https://plugins.gwtproject.org/eclipse/gwt-eclipse-plugin/nightly/` - note that in the future this repo will likely not be signed, and only releases will be signed in this way.

The signing cert here is the same cert as is used by plugins.gwtproject.org itself - we can probably improve the experience here somewhat, but it does seem to be a step up from no signing at all.

Fixes #446