### PR TITLE
Super dev mode for version 2.10.0 is disabled and radio button is hidden

### DIFF
--- a/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/tabs/GWTSettingsTab.java
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/launch/ui/tabs/GWTSettingsTab.java
@@ -744,7 +744,7 @@ public class GWTSettingsTab extends JavaLaunchTab
    * @return true if super dev mode can be used
    */
   private boolean canSdkVersionUseSuperDevMode(String version) {
-    return version.matches("^2.[5-9].*") || version.matches("^[3-9].*");
+    return version.matches("^2.([5-9]|1\\d).*") || version.matches("^[3-9].*");
   }
 
   /**


### PR DESCRIPTION
When importing GWT SDK 2.10.0, I found that radio button group that allows to choose between super development mode and legacy developement mode in the GWT debugging configuration is hidden and argument -nosuperdevmode is forced.

I found that the pattern that decide whether the GWT version supports super dev mode or not excludes 2.10.0.

I know that 2.10.0 still not supported by current plugin but as you see as the code support versions [3-9].* it should also support 2.10.0 version.