### PR TITLE
Update DTD url to HTTPS to avoid Eclipse 2023-03 errors

### DIFF
--- a/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/wizards/NewModuleWizard.java
+++ b/plugins/com.gwtplugins.gwt.eclipse.core/src/com/google/gwt/eclipse/core/wizards/NewModuleWizard.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class NewModuleWizard extends AbstractNewFileWizard {
 
   private static final String NO_VERSION_FOUND_DTD =
-      "<!DOCTYPE module PUBLIC \"-//Google Inc.//DTD GWT//EN\" \"http://gwtproject.org/doctype/2.8.0/gwt-module.dtd\">";
+      "<!DOCTYPE module PUBLIC \"-//Google Inc.//DTD GWT//EN\" \"https://gwtproject.org/doctype/2.8.0/gwt-module.dtd\">";
   private NewModuleWizardPage newModuleWizardPage;
 
   @Override
@@ -140,7 +140,7 @@ public class NewModuleWizard extends AbstractNewFileWizard {
 
       if (!versionNum.endsWith(".999") && !versionNum.startsWith("0.0")) {
         gwtModuleDtd = "<!DOCTYPE module PUBLIC \"-//Google Inc.//DTD Google Web Toolkit " + versionNum
-            + "//EN\" \"http://google-web-toolkit.googlecode.com/svn/tags/" + versionNum
+            + "//EN\" \"https://google-web-toolkit.googlecode.com/svn/tags/" + versionNum
             + "/distro-source/core/src/gwt-module.dtd\">";
       }
     }


### PR DESCRIPTION
Eclipse 2023-03 Shows Language Server Errors when connecting to the GWT http URL for the DTD.  Switching the DTD to the https URL resolves the issue.

Example Errors:
Element type "add-linker" must be declared.	
Element type "entry-point" must be declared.
Element type "inherits" must be declared.
Element type "inherits" must be declared.
Element type "module" must be declared.
Element type "source" must be declared.
Element type "source" must be declared.
There is '1' error in 'http://gwtproject.org/doctype/2.9.0/gwt-module.dtd'.	... Language Servers



It looks very similar to this issue.  (Turning off the XML Language Server setting in Eclipse 2023-03 - hides the error) https://stackoverflow.com/questions/62113303/how-to-avoid-error-messages-in-eclipse-2020-03-for-gwt-ui-xml-files-language-se