### PR TITLE
Upgraded maven-download-plugin

### DIFF
--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt27/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt27/pom.xml
@@ -19,7 +19,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.8</version>
         <executions>
           <execution>
             <id>get-gwt</id>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
@@ -19,7 +19,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.8</version>
         <executions>
           <execution>
             <id>get-gwt</id>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/pom.xml
@@ -19,7 +19,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.8</version>
         <executions>
           <execution>
             <id>get-gwt</id>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -23,7 +23,7 @@
       <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.8</version>
         <executions>
           <execution>
             <id>get-gwt</id>


### PR DESCRIPTION
The plugin is not building anymore.
The maven-download-plugin picks up a cached 2.8.2 plugin instead of the desired 2.7.0
See https://github.com/gwt-plugins/gwt-eclipse-plugin/discussions/465 and https://github.com/gwt-plugins/gwt-eclipse-plugin/issues/467
Upgrading maven-download-plugin seems to fix the issue, at least on WSL

Extract of "mvn -X generate-resources"

```
Configuring mojo 'com.googlecode.maven-download-plugin:download-maven-plugin:1.2.1:
   (f) outputDirectory = /home/luca/gwt-eclipse-plugin/plugins/com.gwtplugins.gwt.ec
   (f) outputFileName = gwt-2.7.0.zip
   (f) overwrite = true
   (f) readTimeOut = 0
   (f) retries = 2
   (f) session = org.apache.maven.execution.MavenSession@5a4098d5
   (f) skip = false
   (f) skipCache = false
   (f) unpack = true
   (f) url = http://goo.gl/t7FQSn
 -- end configuration --
 Cache is: /home/luca/.m2/repository/.cache/maven-download-plugin
Got from cache: /home/luca/.m2/repository/.cache/maven-download-plugin/gwt-2.8.2.zip
```


