### PR TITLE
fixed #474 by removing @Inject annotation

### DIFF
--- a/plugins/com.gwtplugins.gdt.eclipse.suite/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite/META-INF/MANIFEST.MF
@@ -41,6 +41,5 @@ Require-Bundle:
  org.eclipse.equinox.common,
  system.bundle,
  org.eclipse.core.runtime,
- com.gwtplugins.gdt.eclipse.apiclientlib,
- javax.inject;bundle-version="1.0.0"
+ com.gwtplugins.gdt.eclipse.apiclientlib
 Import-Package: org.eclipse.core.runtime.preferences

--- a/plugins/com.gwtplugins.gdt.eclipse.suite/src/com/google/gdt/eclipse/suite/wizards/WebAppProjectCreator.java
+++ b/plugins/com.gwtplugins.gdt.eclipse.suite/src/com/google/gdt/eclipse/suite/wizards/WebAppProjectCreator.java
@@ -83,8 +83,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.inject.Inject;
-
 /**
  * Web application project creator.
  */
@@ -387,6 +385,7 @@ public class WebAppProjectCreator implements IWebAppProjectCreator {
     this.gwtSdk = gwtSdk;
   }
 
+  @Override
   public Sdk getGwtSdk() {
     return gwtSdk;
   }
@@ -407,11 +406,6 @@ public class WebAppProjectCreator implements IWebAppProjectCreator {
         participant.updateWebAppProjectCreator(this);
       }
     }
-  }
-
-  @Inject
-  public void doSomething(IExtensionRegistry registry) {
-    registry.getConfigurationElementsFor("com.gwtplugins.gdt.eclipse.suite.webAppCreatorParticipant");
   }
 
   public List<IPath> getContainerPaths() {


### PR DESCRIPTION
I've removed the dependency to javax.inject completely.
The only method that used the annotation @Inject was the 
doSomething() method in WebAppProjectCreator, but that method seems to do nothing because it just gets some configuration elements without using them.
So i've removed the complete method.
After building the plugin installs in eclipse-2023-12 and seems to work normally.